### PR TITLE
Clean Mode as Comparison Mode

### DIFF
--- a/src/ui_buttons.cpp
+++ b/src/ui_buttons.cpp
@@ -337,16 +337,32 @@ void buttChangedAsid(Button button, bool value) {
 				}
 				break;
 
-			case Button::LFO_RECT: {
+			case Button::LFO_RECT:
 				// Clean mode - no remixing possible
-				bool tmpMode;
 				asidState.isCleanMode = !asidState.isCleanMode;
-				tmpMode = asidState.isCleanMode;
-				asidRestore(-1); // restore both
 
-				// Restore will affect clean mode itself, so need to keep the state
-				asidState.isCleanMode = tmpMode;
-			} break;
+				// full restore by shift
+				if (asidState.isShiftMode) {
+
+					bool tmpMode = asidState.isCleanMode;
+					asidRestore(-1); // restore both
+
+					// Restore will affect clean mode itself, so need to keep the state
+					asidState.isCleanMode = tmpMode;
+				
+				} else {
+
+					// restore isOverride States
+					if (!asidState.isCleanMode) {
+
+						for (byte chip = 0; chip <= SIDCHIPS - 1; chip++) {
+							for (byte voice = 0; voice < 3; voice++) {
+								if (asidState.isOverridePW[chip][voice]) asidUpdateWidth(chip, voice);
+							}
+						}
+					}
+				}
+				break;
 
 			case Button::RETRIG:
 				// SID 1 select-button (SID 3 by combo)


### PR DESCRIPTION
- it's a simple solution, but it allows a lot of remixing features:

-- AC toggle does not restore the values (it hides these values, but they remain)
-- a lot of params can be preconfigured in AC before switch back to AS
-- AC (as comparison) only works as well as new data comes in
-- AC indicates changes the same way as in remix mode
-- SH + AC acts like before

necessary adaptations:
- the pulse width is explicitly updated when switching back to remix mode
- the filter mode selection is adjusted so that it works in AC mode (like all other parameters)