### PR TITLE
Fixed: SOLO/MUTE Chip handling

### DIFF
--- a/include/asid.h
+++ b/include/asid.h
@@ -33,7 +33,9 @@ void asidFmUpdateOpLevel(byte oper);
 void asidAdvanceDefaultChip(bool isUp);
 void asidSelectDefaultChip(byte chip);
 void asidClearDefaultChip();
-void asidUpdateOverrides();
+void asidUpdateLastRemixState(int chip);
+void asidUpdateOverrides(int chip);
+void asidRawResetRegisterChip(byte chip);
 
 #define SID_REGISTERS_ASID (SID_REGISTERS + 3)
 
@@ -85,7 +87,7 @@ struct asidState_t {
 	int adjustCutoff[SIDCHIPS];
 	int adjustReso[SIDCHIPS];
 	FilterMode filterMode[SIDCHIPS];
-	bool muteFilterMode[SIDCHIPS];
+	bool muteChip[SIDCHIPS];
 
 #ifdef ASID_VOLUME_ADJUST
 	int adjustVolume[SIDCHIPS];

--- a/src/ui_buttons.cpp
+++ b/src/ui_buttons.cpp
@@ -278,11 +278,16 @@ bool updateChipSoloStatus() {
 
 	// Update SID chip channels & filtermode mute status
 	for (byte c = 0; c < SIDCHIPS; c++) {
-		for (byte v = 0; v < SIDVOICES_PER_CHIP; v++) {
-			asidState.muteChannel[c][v] = shouldSolo && (soloChip != c);
-		}
 
-		asidState.muteFilterMode[c] = shouldSolo && (soloChip != c);
+		bool shouldMute = shouldSolo && (soloChip != c);
+
+		asidState.muteChip[c] = shouldMute;
+
+		if (shouldMute) {
+			asidRawResetRegisterChip(c);
+		} else {
+			asidUpdateLastRemixState(c);
+		}
 	}
 
 	// Update FM channels mute status
@@ -357,7 +362,7 @@ void buttChangedAsid(Button button, bool value) {
 				} else {
 
 					// Restore isOverride States
-					asidUpdateOverrides();
+					asidUpdateOverrides(-1);
 				}
 				break;
 
@@ -506,7 +511,7 @@ void buttChangedAsid(Button button, bool value) {
 						}
 
 						// RIO: should a complete chip be muted? then:
-						// asidState.muteFilterMode[c] = shouldSolo;
+						// asidState.muteChip[c] = shouldSolo;
 					}
 
 					// For FM channels, mute all but the soloed one (or unmute all)


### PR DESCRIPTION
- Chip soloing should be separated and no longer interfere with mute channels
- Chip soloing no longer hides or mutes individual data, but the unsoloed chips are simply no longer treated as incoming data
- Mute channels can be used as remix status in the indicator