### PR TITLE
fix: Handling of chip solo for 2/3SID/FM

### DIFF
--- a/include/asid.h
+++ b/include/asid.h
@@ -35,7 +35,7 @@ void asidSelectDefaultChip(byte chip);
 void asidClearDefaultChip();
 void asidUpdateLastRemixState(int chip);
 void asidUpdateOverrides(int chip);
-void asidRawResetRegisterChip(byte chip);
+void asidMuteSidChip(byte chip);
 
 #define SID_REGISTERS_ASID (SID_REGISTERS + 3)
 
@@ -48,6 +48,10 @@ void asidRawResetRegisterChip(byte chip);
 // Finetune is multiplication value to be divided by 1024. This means +/-53
 // cents but from center position -26 (to fix PAL C64 vs 1MHz clock)
 // Thereby range = -80/+28. (i.e from 978/1024 to 1042/1024)
+
+#define ASID_SOLO_FLAG_SID_CHIP 0x10
+#define ASID_SOLO_FLAG_FM_CHANNEL 0x20
+#define ASID_SOLO_FLAG_NO_SOLO 0x40
 
 enum class WaveformState { SIDFILE, RECT, TRI, SAW, NOISE_ONLY, RT, TS, RS, RTS };
 enum class OverrideState { SIDFILE, ON, OFF };
@@ -111,7 +115,7 @@ struct asidState_t {
 
 	int8_t defaultSelectedChip;
 	bool isSoloButtonHeld;
-	int8_t soloedChannel;
+	byte soloedChannel;
 
 	byte selectButtonCounter;
 

--- a/src/asid.cpp
+++ b/src/asid.cpp
@@ -193,7 +193,7 @@ void asidInit(int chip) {
 	asidState.defaultSelectedChip = -1;
 	asidState.isSoloButtonHeld = false;
 	asidState.selectButtonCounter = 0;
-	asidState.soloedChannel = -1;
+	asidState.soloedChannel = ASID_SOLO_FLAG_NO_SOLO;
 	asidState.lastDuplicatedChip = asidState.isSidFmMode ? 0 : 1;
 
 	// FM Channels
@@ -904,7 +904,10 @@ void handleAsidFrameUpdate(byte currentChip, byte* buffer) {
 	// Send all updated SID registers
 	for (chip = currentChip; chip <= max(currentChip, asidState.lastDuplicatedChip); chip++) {
 
-		if (asidState.muteChip[chip]) continue;
+		if (asidState.muteChip[chip]) {
+			// Ignore sending SID data to chip if muted, as some changes can cause pops
+			continue;
+		}
 
 		asidReg = 0;
 		for (maskByte = 0; maskByte < 4; maskByte++) {
@@ -1054,7 +1057,7 @@ void asidProcessMessage(byte* buffer, int size) {
 			// Stop playback
 			// reset registers raw, so remix state is kept
 			for (byte chip = 0; chip < SIDCHIPS; chip++) {
-				asidRawResetRegisterChip(chip);
+				asidMuteSidChip(chip);
 			}
 			break;
 
@@ -1688,15 +1691,16 @@ void asidUpdateLastRemixState(int chip) {
 }
 
 /*
- * Reset register raw
+ * Mute the SID chip
  */
-void asidRawResetRegisterChip(byte chip) {
+void asidMuteSidChip(byte chip) {
 	// take care about active fm chips > 0
 	if (chip > 0 && asidState.isSidFmMode) {
 		return;
 	}
 
-	for (size_t reg = 0; reg < SID_REGISTERS; reg++) {
-		sid_chips[chip].send_update_immediate(reg, 0);
+	// Mute each SID voice in this chip
+	for (byte v = 0; v < SIDVOICES_PER_CHIP; v++) {
+		sid_chips[chip].send_update_immediate(SID_VC_CONTROL + 7 * v, 0);
 	}
 }

--- a/src/ui_buttons.cpp
+++ b/src/ui_buttons.cpp
@@ -266,27 +266,36 @@ bool updateChipSoloStatus() {
 	}
 
 	// Find out if a chip should be soloed or umute all
-	if (asidState.soloedChannel == 16 + soloChip) {
+	if (asidState.soloedChannel == ASID_SOLO_FLAG_SID_CHIP + soloChip) {
 		// This chip is already soloed => unmute all
 		shouldSolo = false;
-		asidState.soloedChannel = -1;
+		asidState.soloedChannel = ASID_SOLO_FLAG_NO_SOLO;
 	} else {
 		// Solo the selected chip
 		shouldSolo = true;
-		asidState.soloedChannel = 16 + soloChip;
+		asidState.soloedChannel = ASID_SOLO_FLAG_SID_CHIP + soloChip;
 	}
 
-	// Update SID chip channels & filtermode mute status
+	// Update SID chip channels & chip mute status
 	for (byte c = 0; c < SIDCHIPS; c++) {
+		bool shouldMuteChip = shouldSolo && (soloChip != c);
 
-		bool shouldMute = shouldSolo && (soloChip != c);
-
-		asidState.muteChip[c] = shouldMute;
-
-		if (shouldMute) {
-			asidRawResetRegisterChip(c);
+		if (asidState.lastDuplicatedChip == 0) {
+			// SID chips are not duplicated (2SID/3SID/SID+FM-mode)
+			// Handle chip solo like channel mutes
+			for (byte v = 0; v < SIDVOICES_PER_CHIP; v++) {
+				asidState.muteChannel[c][v] = shouldMuteChip;
+			}
 		} else {
-			asidUpdateLastRemixState(c);
+			// SID chips are duplicated (1SID-mode)
+			// Handle chip solo as chip mute (keeping channel mutes intact)
+			asidState.muteChip[c] = shouldMuteChip;
+
+			if (shouldMuteChip) {
+				asidMuteSidChip(c);
+			} else {
+				asidUpdateLastRemixState(c);
+			}
 		}
 	}
 
@@ -297,7 +306,7 @@ bool updateChipSoloStatus() {
 		}
 	}
 
-	return asidState.soloedChannel != -1;
+	return asidState.soloedChannel != ASID_SOLO_FLAG_NO_SOLO;
 }
 
 void buttChangedAsid(Button button, bool value) {
@@ -307,7 +316,6 @@ void buttChangedAsid(Button button, bool value) {
 		byte chip;
 
 		bool all = false;
-		bool checkMoreButtons = false;
 
 		// Find out what chips are selected
 		// If one pressed - execute actions only on that chip
@@ -368,29 +376,16 @@ void buttChangedAsid(Button button, bool value) {
 
 			case Button::RETRIG:
 				// SID 1 select-button (SID 3 by combo)
-				asidSelectDefaultChip(asidState.selectButtonCounter ? 2 : 0);
-
-				// Solo entire chip
-				if (asidState.isSoloButtonHeld && !updateChipSoloStatus() && !asidState.selectButtonCounter) {
-					asidClearDefaultChip();
-				}
-
-				// increment select counter
-				if (SIDCHIPS > 2) {
-					asidState.selectButtonCounter++;
-				}
-				break;
-
 			case Button::LOOP:
 				// SID 2 select-button (SID 3 by combo)
-				asidSelectDefaultChip(asidState.selectButtonCounter ? 2 : 1);
+				asidSelectDefaultChip(asidState.selectButtonCounter ? 2 : (button == Button::RETRIG ? 0 : 1));
 
 				// Solo entire chip
 				if (asidState.isSoloButtonHeld && !updateChipSoloStatus() && !asidState.selectButtonCounter) {
 					asidClearDefaultChip();
 				}
 
-				// increment select counter
+				// Increment select counter to handle SID 3
 				if (SIDCHIPS > 2) {
 					asidState.selectButtonCounter++;
 				}
@@ -444,13 +439,7 @@ void buttChangedAsid(Button button, bool value) {
 
 			default:
 				// Other press => continue to check buttons
-				checkMoreButtons = true;
 				break;
-		}
-
-		if (!checkMoreButtons) {
-			// Done, no indication update
-			return;
 		}
 
 		// Check chip-specific buttons
@@ -494,21 +483,18 @@ void buttChangedAsid(Button button, bool value) {
 					// If already soloed, unmute all
 
 					bool shouldSolo;
-					if (asidState.soloedChannel == 32 + muteFMChannelIdx) {
+					if (asidState.soloedChannel == ASID_SOLO_FLAG_FM_CHANNEL + muteFMChannelIdx) {
 						// The pressed channel is already soloed => remove solo and unmute all
 						shouldSolo = false;
-						asidState.soloedChannel = -1;
+						asidState.soloedChannel = ASID_SOLO_FLAG_NO_SOLO;
 					} else {
 						// Store solo state and mute all other channels
 						shouldSolo = true;
-						asidState.soloedChannel = 32 + muteFMChannelIdx;
+						asidState.soloedChannel = ASID_SOLO_FLAG_FM_CHANNEL + muteFMChannelIdx;
 					}
 
 					// Mute/unmute all SID channels
 					for (byte c = 0; c < SIDCHIPS; c++) {
-
-						if (asidState.muteChip[c]) continue;
-
 						for (byte v = 0; v < SIDVOICES_PER_CHIP; v++) {
 							asidState.muteChannel[c][v] = shouldSolo;
 						}
@@ -523,7 +509,7 @@ void buttChangedAsid(Button button, bool value) {
 					asidState.muteFMChannel[muteFMChannelIdx] = !asidState.muteFMChannel[muteFMChannelIdx];
 
 					// Reset soloed status
-					asidState.soloedChannel = -1;
+					asidState.soloedChannel = ASID_SOLO_FLAG_NO_SOLO;
 				}
 			}
 
@@ -556,7 +542,7 @@ void buttChangedAsid(Button button, bool value) {
 						if (asidState.soloedChannel == (chip * 3 + index)) {
 							// The pressed channel is already soloed => remove solo and unmute all
 							shouldSolo = false;
-							asidState.soloedChannel = -1;
+							asidState.soloedChannel = ASID_SOLO_FLAG_NO_SOLO;
 						} else {
 							// Store solo state and mute all other channels
 							shouldSolo = true;
@@ -565,8 +551,6 @@ void buttChangedAsid(Button button, bool value) {
 
 						// Mute all but the soloed SID channel (or unmute all)
 						for (byte c = 0; c < SIDCHIPS; c++) {
-
-							if (asidState.muteChip[c]) continue;
 
 							for (byte v = 0; v < SIDVOICES_PER_CHIP; v++) {
 								asidState.muteChannel[c][v] = shouldSolo && !((c == chip || all) && (v == index));
@@ -592,7 +576,7 @@ void buttChangedAsid(Button button, bool value) {
 							}
 
 							// Reset soloed status
-							asidState.soloedChannel = -1;
+							asidState.soloedChannel = ASID_SOLO_FLAG_NO_SOLO;
 						}
 					}
 
@@ -674,6 +658,11 @@ void buttChangedAsid(Button button, bool value) {
 
 			case Button::RETRIG:
 			case Button::LOOP:
+				// Decrement select counter, for SID 3 usage
+				if ((SIDCHIPS > 2) && (asidState.selectButtonCounter)) {
+					asidState.selectButtonCounter--;
+				}
+
 				if (!asidState.isSoloButtonHeld) {
 
 					// validate selection
@@ -681,7 +670,7 @@ void buttChangedAsid(Button button, bool value) {
 						asidClearDefaultChip();
 
 						// Reset soloed status
-						asidState.soloedChannel = -1;
+						asidState.soloedChannel = ASID_SOLO_FLAG_NO_SOLO;
 
 					} else {
 
@@ -689,12 +678,6 @@ void buttChangedAsid(Button button, bool value) {
 						asidSelectDefaultChip(button == Button::RETRIG ? 1 : 0);
 					}
 				}
-
-				// decrement select counter
-				if (asidState.selectButtonCounter) {
-					asidState.selectButtonCounter--;
-				}
-
 				break;
 
 			case Button::ARP_MODE:


### PR DESCRIPTION
* Fixed issue with 3SID solo functionality
* Using mute channels also for chip solo, to have consistent functionality and indication for all song types (1/2/3/SID+FM)
* Replaced dedicated mute chip variable with existing solo flag
* Defined the constants for solo flags
